### PR TITLE
Обновлен скрипт создания конкурса.

### DIFF
--- a/Rauthor/Views/Competition/Create.cshtml
+++ b/Rauthor/Views/Competition/Create.cshtml
@@ -19,13 +19,13 @@
                 </div>
                 <div class="imgText">
                     <img class="imgText__img imgSvg imgSvg_color_white" src="~/img/Competition/email.svg">
-                    <input class="createCompetition__textbox createCompetition__textbox_theme_light imgText__text" name="phoneNumber" type="email" placeholder="Введите почту">
+                    <input class="createCompetition__textbox createCompetition__textbox_theme_light imgText__text" name="email" type="email" placeholder="Введите почту">
                 </div>
             </div>
         </div>
         <div class="createCompetition__banner banner banner_theme_none banner_padding_small">
             <label class="createCompetition__label createCompetition__label_theme_dark">Ежедневный конкурс</label>
-            <input class="createCompetition__textbox createCompetition__textbox_font_header createCompetition__textbox_theme_dark" name="title" type="text" placeholder="Введите название конкурса">
+            <input class="createCompetition__textbox createCompetition__textbox_font_header createCompetition__textbox_theme_dark" name="title" type="text" placeholder="Введите название конкурса" required>
             <label class="createCompetition__label createCompetition__label_theme_dark">Описание идеи конкурса</label>
             <textarea class="createCompetition__shortDescription createCompetition__textarea createCompetition__textarea_theme_dark" name="shortDescription" rows="5">Начните вводить текст...</textarea>
             <a class="createCompetition__uploadBackgroundImg" href="#">
@@ -44,8 +44,8 @@
             <div class="createCompetition__conditions">
                 <h2 class="createCompetition__header">Задайте условия конкурса</h2>
                     <label class="createCompetition__label">*Выберите возраст учатников</label>
-                    <input class="createCompetition__textbox createCompetition__textbox_theme_light createCompetition__textbox_type_range" name="ageStart" type="number" placeholder="От">
-                    <input class="createCompetition__textbox createCompetition__textbox_theme_light createCompetition__textbox_type_range" name="ageEnd" type="number" placeholder=" До">
+                    <input class="createCompetition__textbox createCompetition__textbox_theme_light createCompetition__textbox_type_range" name="ageStart" type="number" placeholder="От" required>
+                    <input class="createCompetition__textbox createCompetition__textbox_theme_light createCompetition__textbox_type_range" name="ageEnd" type="number" placeholder=" До" required>
                     <label class="createCompetition__label">*Страны учаcтников</label>
                     <input class="createCompetition__textbox createCompetition__textbox_theme_light createCompetition__textbox_type_nomralText" name="countries" type="text" placeholder="#Все">
                     <label class="createCompetition__label">*Ссылка на подробные условия</label>
@@ -135,24 +135,18 @@
                 <input class="createCompetition__textbox createCompetition__textbox_theme_light createCompetition__textbox_type_nomralText" name="currentURL" type="text" placeholder="В разработке">
             </div>
         </div>
+        <label class="createCompetition__label">Дата публикации</label>
+        <input class="createCompetition__date" name="publicationDate" type="date" required>
+        <label class="createCompetition__label">Дата начала конкурса</label>
+        <input class="createCompetition__date" name="startDate" type="date" required>
+        <label class="createCompetition__label">Дата конца конкурса</label>
+        <input class="createCompetition__date" name="endDate" type="date" required>
     </div>
     <div class="createCompetition__buttons">
         <input class="createCompetition__button createCompetition__saveDraft formButton" type="button" value="Сохранить черновик" />
         <input class="createCompetition__button createCompetition__publish formButton" type="submit" value="Опубликовать" />
     </div>
 </form>
-
-
-<!--<form id="main-form">
-    <ul>
-        <li><label>Title</label><input name="title" type="text" placeholder="title" /></li>
-        <li><label>Start date</label><input name="startDate" type="date" /></li>
-        <li><label>End date</label><input name="endDate" type="date" /></li>
-        <li><label>Description</label><textarea name="description"></textarea></li>
-        <li><label>Prizes</label><textarea name="prizes"></textarea></li>
-        <li><button>Create</button></li>
-    </ul>
-</form> -->
 
 <script asp-src-include="/js/Competition/create.js"></script>
 <script asp-src-include="/js/Competition/all.js"></script>

--- a/Rauthor/wwwroot/js/Competition/create.js
+++ b/Rauthor/wwwroot/js/Competition/create.js
@@ -1,24 +1,47 @@
-/// <reference path="../Core/models.ts" />
-var Competition;
-(function (Competition) {
-    var Create;
-    (function (Create) {
-        document.addEventListener("readystatechange", () => {
-            let form = document.getElementById("main-form");
-            form.addEventListener("submit", create);
-        });
-        async function create(event) {
-            event.preventDefault();
-            let competition = new Core.Models.Competition(this.title.value, this.startDate.value, this.endDate.value, this.description.value, this.prizes.value);
-            await fetch('/api/competition', {
-                body: JSON.stringify(competition),
-                method: "POST",
-                headers: [
-                    ["Content-Type", "application/json"]
-                ]
-            });
-            return false;
+let competitionForm = document.forms[0];
+competitionForm.addEventListener("submit", CreateCompetition);
+
+function CreateCompetition() {
+    event.preventDefault();
+    let competitionForm = document.forms[0];
+    let competition = {
+        "ManagerPhoneNumber": competitionForm.phoneNumber.value,
+        "ManagerEmail": competitionForm.email.value,
+        "ManagerSocialLinks": [],
+        "Categories": [],
+        "Title": competitionForm.title.value,
+        "ShortDescription": competitionForm.shortDescription.value,
+        "Description": competitionForm.description.value,
+        "Constraints": [
+            {
+                "CheckedValue": "Age",
+                "Min": parseInt(competitionForm.ageStart.value, 10),
+                "Max": parseInt(competitionForm.ageEnd.value, 10)
+            },
+            {
+                "CheckedValue": "Country",
+                "Value": competitionForm.countries.valuet
+            }
+        ],
+        "Prizes": "null",
+        "JuryGuids": [],
+        "PublicationDate": competitionForm.publicationDate.value,
+        "StartDate": competitionForm.startDate.value,
+        "EndDate": competitionForm.endDate.value
+    }    
+
+    fetch("/api/Competition", {
+        method: 'POST', 
+        headers: {
+            "Content-Type": "text/json; charset=utf-8"
+        }, 
+        body: JSON.stringify(competition)
+    }).then(response => {
+        if (response.status == 200) {
+            document.location.href = "/";
         }
-    })(Create = Competition.Create || (Competition.Create = {}));
-})(Competition || (Competition = {}));
-//# sourceMappingURL=create.js.map
+        else {
+            alert(`Ошибка: ${response.status}`);
+        }
+    });
+}


### PR DESCRIPTION
Под новый интерфейс создания конкурса был обновлен соответствующий ему скрипт.
Скрипт:
1. Слушает событие формы "onsubmit"
2. Создает объект competition, заполняя его данными с формы
3. Сериализует объект в JSON файл
4. Отправляет данные на сервер через api/competition с помощью POST запроса метода fetch
5. Проверяет ответ сервера. Если его статус 200 (ОК) - перенаправляет пользователя на главную, иначе выводит ошибку с кодом ошибки через alert.

На данный момент можно создавать конкурсы с минимальным набором данных, которые отмечены атрибутом **required** в HTML форме. 

На страницу добавлены даты создания конкурса, а также его завершения. Их дизайн является временным, пока дизайнер не добавит их в макет. 
Коммит закрывает #28 и затрагивает #7.