### PR TITLE
Api-контроллер для соревнований

### DIFF
--- a/Rauthor/Controllers/Api/CompetitionController.cs
+++ b/Rauthor/Controllers/Api/CompetitionController.cs
@@ -21,20 +21,18 @@ namespace Rauthor.Controllers.Api
             database = db;
         }
 
-        [Authorize(Roles = "User")]
         [HttpGet]
-        public IEnumerable<Competition> Get()
+        public IActionResult Get()
         {
-            return database.Competitions;
+            return Ok(database.Competitions);
         }
 
-        [Authorize(Roles = "User")]
         [HttpGet("{guid}", Name = "Get")]
-        public string Get(Guid guid)
+        public IActionResult Get(Guid guid)
         {
             var value = database.Competitions.Include(x => x.Participants).Where(x => x.Guid == guid).Single();
             value.Participants = value.Participants.Select(x => { x.Competition = null; return x; }).ToList();
-            return Newtonsoft.Json.JsonConvert.SerializeObject(value);
+            return Ok(value);
         }
 
         [Authorize(Roles = "Admin, Manager")]
@@ -42,6 +40,7 @@ namespace Rauthor.Controllers.Api
         public IActionResult Post([FromBody] ViewModels.Api.Competition value)
         {
             var competition = Competition.FromApiViewModel(value);
+            competition.Guid = Guid.NewGuid();
             database.Competitions.Add(competition);
             database.SaveChanges();
             return Ok();

--- a/Rauthor/Controllers/Api/CompetitionController.cs
+++ b/Rauthor/Controllers/Api/CompetitionController.cs
@@ -39,10 +39,33 @@ namespace Rauthor.Controllers.Api
 
         [Authorize(Roles = "Admin, Manager")]
         [HttpPost]
-        public IActionResult Post([FromBody] Competition value)
+        public IActionResult Post([FromBody] ViewModels.Api.Competition value)
         {
             value.Guid = Guid.NewGuid();
-            database.Competitions.Add(value);
+            var competition = new Competition()
+            {
+                Guid = value.Guid.Value,
+                Constraints = value.Constraints,
+                StartDate = value.StartDate,
+                EndDate = value.EndDate,
+                Description = value.Description,
+                ShortDesctiption = value.ShortDescription,
+                Prizes = value.Prizes.ToString(),
+                Title = value.Title,
+            };
+            var juryRefernces = value.JuryGuids.Select(juryGuid => new CompetitionRelJury()
+            {
+                CompetitionGuid = competition.Guid,
+                JuryUserGuid = juryGuid
+            });
+            var categoryReferences = value.Categories.Select(categoryGuid => new CompetitionRelCategory()
+            {
+                CompetitionGuid = competition.Guid,
+                CategoryGuid = categoryGuid
+            });
+            database.Competitions.Add(competition);
+            database.CompetitionRelJuries.AddRange(juryRefernces);
+            database.CompetitionRelCategories.AddRange(categoryReferences);
             database.SaveChanges();
             return Ok();
         }

--- a/Rauthor/Controllers/Api/CompetitionController.cs
+++ b/Rauthor/Controllers/Api/CompetitionController.cs
@@ -41,42 +41,19 @@ namespace Rauthor.Controllers.Api
         [HttpPost]
         public IActionResult Post([FromBody] ViewModels.Api.Competition value)
         {
-            value.Guid = Guid.NewGuid();
-            var competition = new Competition()
-            {
-                Guid = value.Guid.Value,
-                Constraints = value.Constraints,
-                StartDate = value.StartDate,
-                EndDate = value.EndDate,
-                Description = value.Description,
-                ShortDesctiption = value.ShortDescription,
-                Prizes = value.Prizes.ToString(),
-                Title = value.Title,
-            };
-            var juryRefernces = value.JuryGuids.Select(juryGuid => new CompetitionRelJury()
-            {
-                CompetitionGuid = competition.Guid,
-                JuryUserGuid = juryGuid
-            });
-            var categoryReferences = value.Categories.Select(categoryGuid => new CompetitionRelCategory()
-            {
-                CompetitionGuid = competition.Guid,
-                CategoryGuid = categoryGuid
-            });
+            var competition = Competition.FromApiViewModel(value);
             database.Competitions.Add(competition);
-            database.CompetitionRelJuries.AddRange(juryRefernces);
-            database.CompetitionRelCategories.AddRange(categoryReferences);
             database.SaveChanges();
             return Ok();
         }
         
         [Authorize(Roles = "Admin, Manager")]
         [HttpPut("{guid}")]
-        public IActionResult Put(Guid guid, [FromBody] Competition value)
+        public IActionResult Put(Guid guid, [FromBody] ViewModels.Api.Competition value)
         {
             var oldValue = database.Competitions.Where(x => x.Guid == guid).Single();
             value.Guid = guid;
-            database.Entry(oldValue).CurrentValues.SetValues(value);
+            database.Entry<Competition>(oldValue).CurrentValues.SetValues(Competition.FromApiViewModel(value));
             database.SaveChanges();
             return Ok();
         }

--- a/Rauthor/Models/Competition.cs
+++ b/Rauthor/Models/Competition.cs
@@ -58,6 +58,8 @@ namespace Rauthor.Models
             Guid = Guid.NewGuid();
             Participants = new List<Participant>();
             Categories = new List<CompetitionRelCategory>();
+            Jury = new List<CompetitionRelJury>();
+            Constraints = new List<CompetitionConstraint>();
         }
 
         /// <summary>

--- a/Rauthor/Models/Competition.cs
+++ b/Rauthor/Models/Competition.cs
@@ -59,5 +59,38 @@ namespace Rauthor.Models
             Participants = new List<Participant>();
             Categories = new List<CompetitionRelCategory>();
         }
+
+        /// <summary>
+        /// Возвращает экземпляр Competition с заполненными полями и навигационными свойствами, на основе
+        /// модели представления.
+        /// </summary>
+        public static Competition FromApiViewModel(ViewModels.Api.Competition viewModel)
+        {
+            viewModel.Guid = Guid.NewGuid();
+            var competition = new Competition()
+            {
+                Guid = viewModel.Guid.Value,
+                Constraints = viewModel.Constraints,
+                StartDate = viewModel.StartDate,
+                EndDate = viewModel.EndDate,
+                Description = viewModel.Description,
+                ShortDesctiption = viewModel.ShortDescription,
+                Prizes = viewModel.Prizes.ToString(),
+                Title = viewModel.Title,
+            };
+            var juryRefernces = viewModel.JuryGuids.Select(juryGuid => new CompetitionRelJury()
+            {
+                CompetitionGuid = competition.Guid,
+                JuryUserGuid = juryGuid
+            });
+            var categoryReferences = viewModel.Categories.Select(categoryGuid => new CompetitionRelCategory()
+            {
+                CompetitionGuid = competition.Guid,
+                CategoryGuid = categoryGuid
+            });
+            competition.Jury = juryRefernces.ToList();
+            competition.Categories = categoryReferences.ToList();
+            return competition;
+        }
     }
 }

--- a/Rauthor/Models/Competition.cs
+++ b/Rauthor/Models/Competition.cs
@@ -68,10 +68,9 @@ namespace Rauthor.Models
         /// </summary>
         public static Competition FromApiViewModel(ViewModels.Api.Competition viewModel)
         {
-            viewModel.Guid = Guid.NewGuid();
             var competition = new Competition()
             {
-                Guid = viewModel.Guid.Value,
+                Guid = viewModel.Guid ?? default,
                 Constraints = viewModel.Constraints,
                 StartDate = viewModel.StartDate,
                 EndDate = viewModel.EndDate,

--- a/Rauthor/Models/Competition.cs
+++ b/Rauthor/Models/Competition.cs
@@ -68,9 +68,10 @@ namespace Rauthor.Models
         /// </summary>
         public static Competition FromApiViewModel(ViewModels.Api.Competition viewModel)
         {
+            viewModel.Guid = Guid.NewGuid();
             var competition = new Competition()
             {
-                Guid = viewModel.Guid ?? default,
+                Guid = viewModel.Guid.Value,
                 Constraints = viewModel.Constraints,
                 StartDate = viewModel.StartDate,
                 EndDate = viewModel.EndDate,

--- a/Rauthor/Rauthor.ruleset
+++ b/Rauthor/Rauthor.ruleset
@@ -73,6 +73,6 @@
     <Rule Id="CA2242" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
-    <Rule Id="CA1720" Action="Info" />
+    <Rule Id="CA1720" Action="None" />
   </Rules>
 </RuleSet>

--- a/Rauthor/ViewModels/Api/Competition.cs
+++ b/Rauthor/ViewModels/Api/Competition.cs
@@ -80,5 +80,13 @@ namespace Rauthor.ViewModels.Api
         /// Дата окончания приёма заявок
         /// </summary>
         public DateTime EndDate { get; set; }
+
+        public Competition()
+        {
+            JuryGuids = new List<Guid>();
+            Constraints = new List<CompetitionConstraint>();
+            Categories = new List<Guid>();
+            ManagerSocialLinks = new List<string>();
+        }
     }
 }

--- a/Rauthor/ViewModels/Api/Competition.cs
+++ b/Rauthor/ViewModels/Api/Competition.cs
@@ -1,0 +1,84 @@
+﻿using Rauthor.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Rauthor.ViewModels.Api
+{
+    /// <summary>
+    /// Модель используемая api-контроллером соревнований.
+    /// </summary>
+    public class Competition
+    {
+        /// <summary>
+        /// Guid конкурса
+        /// </summary>
+        public Guid? Guid { get; set; }
+
+        /// <summary>
+        /// Номер телефона организатора
+        /// </summary>
+        public string ManagerPhoneNumber { get; set; }
+
+        /// <summary>
+        /// Электронная почта организатора
+        /// </summary>
+        public string ManagerEmail { get; set; }
+        
+        /// <summary>
+        /// Социальные сети организатора
+        /// </summary>
+        public List<string> ManagerSocialLinks { get; set; }
+
+        /// <summary>
+        /// Категория конкурса
+        /// </summary>
+        public List<Guid> Categories { get; set; }
+
+        /// <summary>
+        /// НАзвание конкурса
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Короткое описание конкурса
+        /// </summary>
+        public string ShortDescription { get; set; }
+
+        /// <summary>
+        /// Полное описание конкурса
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Условия конкурса
+        /// </summary>
+        public List<CompetitionConstraint> Constraints { get; set; }
+
+        /// <summary>
+        /// Призовые места
+        /// </summary>
+        public object Prizes { get; set; }
+
+        /// <summary>
+        /// Guid'ы жюри конкурса
+        /// </summary>
+        public List<Guid> JuryGuids { get; set; }
+
+        /// <summary>
+        /// Дата публикации конкурса
+        /// </summary>
+        public DateTime PublicationDate { get; set; }
+
+        /// <summary>
+        /// Дата начала приёма заявок
+        /// </summary>
+        public DateTime StartDate { get; set; }
+
+        /// <summary>
+        /// Дата окончания приёма заявок
+        /// </summary>
+        public DateTime EndDate { get; set; }
+    }
+}


### PR DESCRIPTION
В работе над #43, #1, #8 и #47 
Добавлен api-контроллер, обеспечивающий весь набор взаимодействий касающихся соревнований: создание, удаление, обновление и получение информации.
Добавлены новые модели, соответствующие требованиям дизайна.

Алсо, добавил в игнор назойливую ошибку, которая постоянно тригеррилась на `Guid Guid { get; }` и `Foo(Guid guid)`.

Тесты  на нововведения в другой ветке (не все умеют правильно пользоваться гитом).