### PR TITLE
Призы за победу в соревновании.

### DIFF
--- a/Rauthor.UnitTests/Controllers/Database.cs
+++ b/Rauthor.UnitTests/Controllers/Database.cs
@@ -155,8 +155,8 @@ namespace Rauthor.UnitTests.Controllers
             });
 
             db.Prizes.Add(new Prize() { Guid = guid[11], BeginPlace = 1, EndPlace = 1, CompetitionGuid = guid[9], Value = @string[6] });
-            db.Prizes.Add(new Prize() { Guid = guid[11], BeginPlace = @int[2], EndPlace = @int[2]+1, CompetitionGuid = guid[9], Value = @string[7] });
-            db.Prizes.Add(new Prize() { Guid = guid[11], BeginPlace = @int[3], EndPlace = @int[3]+@int[4], CompetitionGuid = guid[9], Value = @string[8] });
+            db.Prizes.Add(new Prize() { Guid = guid[12], BeginPlace = @int[2], EndPlace = @int[2]+1, CompetitionGuid = guid[9], Value = @string[7] });
+            db.Prizes.Add(new Prize() { Guid = guid[13], BeginPlace = @int[3], EndPlace = @int[3]+@int[4], CompetitionGuid = guid[9], Value = @string[8] });
 
             db.SaveChanges();
         }

--- a/Rauthor.UnitTests/Controllers/Database.cs
+++ b/Rauthor.UnitTests/Controllers/Database.cs
@@ -137,7 +137,6 @@ namespace Rauthor.UnitTests.Controllers
                 StartDate = new DateTime(2020, 3, 15),
                 Title = "Title sample",
                 ShortDesctiption = "Short description sample",
-                Prizes = "null",
             });
 
             db.CompetitionConstraints.Add(new CompetitionConstraint()
@@ -154,6 +153,10 @@ namespace Rauthor.UnitTests.Controllers
                 CategoryGuid = guid[8],
                 CompetitionGuid = guid[9]
             });
+
+            db.Prizes.Add(new Prize() { Guid = guid[11], BeginPlace = 1, EndPlace = 1, CompetitionGuid = guid[9], Value = @string[6] });
+            db.Prizes.Add(new Prize() { Guid = guid[11], BeginPlace = @int[2], EndPlace = @int[2]+1, CompetitionGuid = guid[9], Value = @string[7] });
+            db.Prizes.Add(new Prize() { Guid = guid[11], BeginPlace = @int[3], EndPlace = @int[3]+@int[4], CompetitionGuid = guid[9], Value = @string[8] });
 
             db.SaveChanges();
         }

--- a/Rauthor.UnitTests/Database/BasicDatabaseTests.cs
+++ b/Rauthor.UnitTests/Database/BasicDatabaseTests.cs
@@ -68,5 +68,11 @@ namespace Rauthor.UnitTests.Database
         {
             TestForEntity(db => db.Roles);
         }
+
+        [Fact]
+        public void PrizesLoading()
+        {
+            TestForEntity(db => db.Prizes);
+        }
     }
 }

--- a/Rauthor.UnitTests/Database/DatabaseRelationsTests.cs
+++ b/Rauthor.UnitTests/Database/DatabaseRelationsTests.cs
@@ -22,12 +22,14 @@ namespace Rauthor.UnitTests.Database
             var entity = Database.Competitions
                 .Include(x => x.Categories)
                 .Include(x => x.Constraints)
-                .Include(x => x.Participants);
+                .Include(x => x.Participants)
+                .Include(x => x.Prizes);
             Assert.All(entity, item =>
             {
                 AssertMany(item.Categories);
                 AssertMany(item.Constraints);
                 AssertMany(item.Participants);
+                AssertMany(item.Prizes);
             });
         }
 

--- a/Rauthor/DatabaseContext.cs
+++ b/Rauthor/DatabaseContext.cs
@@ -23,6 +23,8 @@ namespace Rauthor
         public DbSet<CompetitionRelJury> CompetitionRelJuries { get; set; }
         public DbSet<UserProfile> Profiles { get; set; }
         public DbSet<Role> Roles { get; set; }
+        public DbSet<Prize> Prizes { get; set; }
+
         public DatabaseContext(DbContextOptions<DatabaseContext> options) : base(options)
         {
             Database.EnsureCreated();

--- a/Rauthor/Models/Competition.cs
+++ b/Rauthor/Models/Competition.cs
@@ -42,8 +42,8 @@ namespace Rauthor.Models
         [Column("short_description")]
         public string ShortDesctiption { get; set; }
 
-        [Column("prizes")]
-        public string Prizes { get; set; }
+        [ForeignKey("CompetitionGuid")]
+        public List<Prize> Prizes { get; set; }
 
         public virtual List<Participant> Participants { get; set; }
 

--- a/Rauthor/Models/Competition.cs
+++ b/Rauthor/Models/Competition.cs
@@ -75,7 +75,6 @@ namespace Rauthor.Models
                 EndDate = viewModel.EndDate,
                 Description = viewModel.Description,
                 ShortDesctiption = viewModel.ShortDescription,
-                Prizes = viewModel.Prizes.ToString(),
                 Title = viewModel.Title,
             };
             var juryRefernces = viewModel.JuryGuids.Select(juryGuid => new CompetitionRelJury()

--- a/Rauthor/Models/Competition.cs
+++ b/Rauthor/Models/Competition.cs
@@ -70,7 +70,6 @@ namespace Rauthor.Models
             var competition = new Competition()
             {
                 Guid = viewModel.Guid ?? default,
-                Constraints = viewModel.Constraints,
                 StartDate = viewModel.StartDate,
                 EndDate = viewModel.EndDate,
                 Description = viewModel.Description,
@@ -87,8 +86,20 @@ namespace Rauthor.Models
                 CompetitionGuid = competition.Guid,
                 CategoryGuid = categoryGuid
             });
+            var constrains = viewModel.Constraints.Select(x =>
+            {
+                x.CompetitionGuid = competition.Guid;
+                return x;
+            });
+            var prizes = viewModel.Prizes.Select(x =>
+            {
+                x.CompetitionGuid = competition.Guid;
+                return x;
+            });
             competition.Jury = juryRefernces.ToList();
             competition.Categories = categoryReferences.ToList();
+            competition.Constraints = constrains.ToList();
+            competition.Prizes = prizes.ToList();
             return competition;
         }
     }

--- a/Rauthor/Models/Prize.cs
+++ b/Rauthor/Models/Prize.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Rauthor.Models
+{
+    [Table("prizes")]
+    public class Prize
+    {
+        [Key]
+        [Column("GUID")]
+        public Guid Guid { get; set; }
+
+        [Column("competition_guid")]
+        public Guid CompetitionGuid { get; set; }
+
+        [Column("begin_place")]
+        public int BeginPlace { get; set; }
+        
+        [Column("end_place")]
+        public int EndPlace { get; set; }
+
+        [Column("value")]
+        public string Value { get; set; }
+    }
+}

--- a/Rauthor/ViewModels/Api/Competition.cs
+++ b/Rauthor/ViewModels/Api/Competition.cs
@@ -59,7 +59,7 @@ namespace Rauthor.ViewModels.Api
         /// <summary>
         /// Призовые места
         /// </summary>
-        public object Prizes { get; set; }
+        public List<Prize> Prizes { get; set; }
 
         /// <summary>
         /// Guid'ы жюри конкурса


### PR DESCRIPTION
Продолжение работы над #43 
Необходимость хранения призов не в голом json вызвана тем, что пользователь таки может победить в конкурсе, и у него должна появиться какая-то связь с призом. Таким образом:
1. Призы вынесены в отдельную таблицу в БД.
2. Обновлен класс ViewModels.Api.Competition, призы теперь являются списком объектов типа Prize. 
3. Обновлён api-контроллер соревнований. Он теперь возвращает и принимает json, соответствующий новой модели.