### PR TITLE
Исправлена ошибка маршрутизации (опять)

### DIFF
--- a/Rauthor/Controllers/Api/RoutesController.cs
+++ b/Rauthor/Controllers/Api/RoutesController.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+
+namespace Rauthor.Controllers.Api
+{
+    [Route("api/[controller]")]
+    [Authorize(Roles = "Admin")]
+    [ApiController]
+    public class RoutesController : ControllerBase
+    {
+        private readonly IActionDescriptorCollectionProvider _actionDescriptorCollectionProvider;
+
+        public RoutesController(IActionDescriptorCollectionProvider actionDescriptorCollectionProvider)
+        {
+            this._actionDescriptorCollectionProvider = actionDescriptorCollectionProvider;
+        }
+
+        [HttpGet]
+        public IActionResult Get()
+        {
+            var routes = _actionDescriptorCollectionProvider.ActionDescriptors.Items.Select(x => new {
+                Action = x.RouteValues["Action"],
+                Controller = x.RouteValues["Controller"],
+                Name = x.AttributeRouteInfo?.Name,
+                Template = x.AttributeRouteInfo?.Template,
+                Constraints = x.ActionConstraints
+            }).ToList();
+            return Ok(routes);
+        }
+    }
+}

--- a/Rauthor/Controllers/ProfileController.cs
+++ b/Rauthor/Controllers/ProfileController.cs
@@ -35,8 +35,8 @@ namespace Rauthor.Controllers
         /// `/Profile` будет использоваться не маршрут с методом Index по умолчанию, а маршрут с {shortLink},
         /// `Profile` будет восприниматься как короткая ссылка для профиля.
         /// </remarks>
-        [HttpGet]
-        [Route("{shortLink}", Order = 9000)]
+        //[Route("{shortLink}", Order = 150)]
+        [HttpGet("{shortLink}", Name = "Short profile link", Order = 150)]
         public IActionResult Profile(string shortLink)
         {
             try
@@ -56,7 +56,7 @@ namespace Rauthor.Controllers
             
         }
         [HttpGet]
-        [Route("[controller]/{guid}")]
+        [Route("[controller]/{guid}", Name = "Profile guid link")]
         public IActionResult Profile(Guid guid)
         {
             try

--- a/Rauthor/Startup.cs
+++ b/Rauthor/Startup.cs
@@ -96,12 +96,12 @@ namespace Rauthor
                .UseMvc(routes =>
                {
                    routes.MapRoute(
-                       name: "parameter_guid",
+                       name: "Guid parameter",
                        template: "{controller}/{action}/{guid}",
                        defaults: new { controller="Home", action="Index" },
                        constraints: new { guid = new GuidRouteConstraint() });
                    routes.MapRoute(
-                       name: "action_only",
+                       name: "Only action",
                        template: "{controller=Home}/{action=Index}");
                });
             

--- a/Rauthor/Views/Shared/Header.cshtml
+++ b/Rauthor/Views/Shared/Header.cshtml
@@ -11,7 +11,7 @@
                     <a asp-area="" asp-controller="Home" asp-action="Index">Главная</a>
                 </li>
                 <li>
-                    <a asp-controller="Profile" asp-action="Index">Профиль</a>
+                    <a asp-controller="Profile" asp-action="Profile" asp-route-shortLink="@User.Identity.Name">Профиль</a>
                 </li>
                 @if (User.HasClaim(ClaimTypes.Role, "Moderator"))
                 {
@@ -20,7 +20,7 @@
                     </li>
                 }
                 <li>
-                    <a asp-area="" asp-controller="Account" asp-action="Logout">Выход</a>
+                    <a asp-controller="Account" asp-action="Logout">Выход</a>
                 </li>
                 <li>
                     <a asp-controller="Home" asp-action="Privacy">Privacy</a>


### PR DESCRIPTION
Времени на расследование причин, из за которых предыдущий фикс (#59) перестал работать. Экстренно добавлен костыль: в шапке страницы измена ссылка на профиль: теперь там используется явное указание имени пользователя.
**Важно, что это гарантированно является ошибкой**, потому что имя пользователя не равно короткой ссылке на профиль, которая используется в контроллере профилей. Просто для большинства существующих пользователей на данный момент это так.