### PR TITLE
Использование Dotnet Core 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 ﻿language: csharp
 solution: Rauthor.sln
 mono: none
-dotnet: 2.2
+dotnet: 3.1
+cache:
+  directories:
+  - $HOME/.nuget/packages
 script:
  - dotnet restore
- - dotnet build ./Rauthor.sln -f netcoreapp2.2
+ - dotnet build ./Rauthor.sln -f netcoreapp3.1
  - dotnet test --no-build Rauthor.UnitTests/Rauthor.UnitTests.csproj --filter Category!=DatabaseTest /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
 deploy:
   provider: script

--- a/Rauthor.UnitTests/Rauthor.UnitTests.csproj
+++ b/Rauthor.UnitTests/Rauthor.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Rauthor/Controllers/JuryController.cs
+++ b/Rauthor/Controllers/JuryController.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.EntityFrameworkCore;
 using Rauthor.Models;
 using Rauthor.ViewModels;

--- a/Rauthor/Rauthor.csproj
+++ b/Rauthor/Rauthor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <UserSecretsId>bfdceb32-95b6-49c5-a109-d841b410f47e</UserSecretsId>
     <LangVersion>8.0</LangVersion>


### PR DESCRIPTION
Новая версия поддерживает большой набор фич, в том числе nullable reference types, который нам давно очень нужен чтобы не видеть тысячу сообщений об ошибках при сборке. Так же это ускорит работу сервера и увеличит скорость деплоя на тревисе.