### PR TITLE
Очередная попытка перейти на dotnet 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
 before_install:
  - sudo apt-get -y install powershell
  - sudo apt-get -y install sshpass
+ - dotnet tool install --global dotnet-ef
 script:
  - dotnet restore ./Seterator/Seterator.csproj
  - dotnet restore ./Seterator.UnitTests/Seterator.UnitTests.csproj

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ﻿language: csharp
 solution: Seterator.sln
 mono: none
-dotnet: 2.2
+dotnet: 3.1
 services:
  - mysql
 before_install:
@@ -9,7 +9,7 @@ before_install:
  - sudo apt-get -y install sshpass
 script:
  - dotnet restore
- - dotnet build ./Seterator.sln -f netcoreapp2.2
+ - dotnet build ./Seterator.sln -f netcoreapp3.1
  - dotnet ef database update --project ./Seterator/Seterator.csproj
  - dotnet test --no-build Seterator.UnitTests/Seterator.UnitTests.csproj --filter Category!=DatabaseTest /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
  - dotnet restore ./Seterator.UnitTests/Seterator.UnitTests.csproj
  - dotnet build ./Seterator/Seterator.csproj -f netcoreapp3.1 --no-restore
  - dotnet build ./Seterator.UnitTests/Seterator.UnitTests.csproj -f netcoreapp3.1 --no-restore
- - dotnet ef database update --project ./Seterator/Seterator.csproj
+#- dotnet ef database update --project ./Seterator/Seterator.csproj
  - dotnet test --no-build Seterator.UnitTests/Seterator.UnitTests.csproj --filter Category!=DatabaseTest /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ before_install:
  - sudo apt-get -y install powershell
  - sudo apt-get -y install sshpass
 script:
- - dotnet restore
- - dotnet build ./Seterator.sln -f netcoreapp3.1
+ - dotnet restore ./Seterator/Seterator.csproj
+ - dotnet restore ./Seterator.UnitTests/Seterator.UnitTests.csproj
+ - dotnet build ./Seterator/Seterator.csproj -f netcoreapp3.1 --no-restore
+ - dotnet build ./Seterator.UnitTests/Seterator.UnitTests.csproj -f netcoreapp3.1 --no-restore
  - dotnet ef database update --project ./Seterator/Seterator.csproj
  - dotnet test --no-build Seterator.UnitTests/Seterator.UnitTests.csproj --filter Category!=DatabaseTest /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
 deploy:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/Seterator/bin/Debug/netcoreapp2.2/Seterator.dll",
+            "program": "${workspaceFolder}/Seterator/bin/Debug/netcoreapp3.1/Seterator.dll",
             "args": [],
             "cwd": "${workspaceFolder}/Seterator",
             "stopAtEntry": false,

--- a/Seterator.UnitTests/Seterator.UnitTests.csproj
+++ b/Seterator.UnitTests/Seterator.UnitTests.csproj
@@ -1,19 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Seterator/Controllers/JuryController.cs
+++ b/Seterator/Controllers/JuryController.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.EntityFrameworkCore;
 using Seterator.Models;
 using Seterator.ViewModels;

--- a/Seterator/Properties/launchSettings.json
+++ b/Seterator/Properties/launchSettings.json
@@ -1,27 +1,27 @@
 ﻿{
-  "iisSettings": {
-    "windowsAuthentication": false, 
-    "anonymousAuthentication": true, 
-    "iisExpress": {
-      "applicationUrl": "http://localhost:58468",
-      "sslPort": 44327
-    }
-  },
-  "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+    "iisSettings": {
+        "windowsAuthentication": false,
+        "anonymousAuthentication": true,
+        "iisExpress": {
+            "applicationUrl": "http://localhost:58468",
+            "sslPort": 44327
+        }
     },
-    "Seterator": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+    "profiles": {
+        "IIS Express": {
+            "commandName": "IISExpress",
+            "launchBrowser": true,
+            "environmentVariables": {
+
+            }
+        },
+        "Seterator": {
+            "commandName": "Project",
+            "launchBrowser": true,
+            "applicationUrl": "https://localhost:5001;http://localhost:5000",
+            "environmentVariables": {
+
+            }
+        }
     }
-  }
 }

--- a/Seterator/Seterator.csproj
+++ b/Seterator/Seterator.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <UserSecretsId>bfdceb32-95b6-49c5-a109-d841b410f47e</UserSecretsId>
     <LangVersion>8.0</LangVersion>
+    <Nullable>Enable</Nullable>
   </PropertyGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="pwsh post-build.ps1" IgnoreExitCode="true"/>
+    <Exec Command="pwsh post-build.ps1" IgnoreExitCode="true" />
   </Target>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -34,19 +35,22 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.4" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="3.7.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.4" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="2.2.6" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.1.1" />
     <PackageReference Include="NLog" Version="4.7.0" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.9.1" />
   </ItemGroup>

--- a/Seterator/Startup.cs
+++ b/Seterator/Startup.cs
@@ -37,7 +37,7 @@ namespace Seterator
             }
         }
 
-        public Startup(Microsoft.AspNetCore.Hosting.IHostingEnvironment env, ILogger<Startup> logger)
+        public Startup(Microsoft.AspNetCore.Hosting.IWebHostEnvironment env, ILogger<Startup> logger)
         {
             Contract.Assert(env != null);
             var builder = new ConfigurationBuilder()
@@ -76,12 +76,12 @@ namespace Seterator
                     });
             services
                 .AddMvc()
-                    .SetCompatibilityVersion(CompatibilityVersion.Version_2_2)
+                    .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                     .AddMvcOptions(options => options.EnableEndpointRouting = false);
 
         }
 #pragma warning disable CA1822 // Member Configure does not access instance data and can be marked as static
-        public void Configure(IApplicationBuilder app, Microsoft.AspNetCore.Hosting.IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, Microsoft.AspNetCore.Hosting.IWebHostEnvironment env)
 #pragma warning restore CA1922 
         {
             if (!env.IsDevelopment())

--- a/Seterator/appsettings.json
+++ b/Seterator/appsettings.json
@@ -1,7 +1,7 @@
 {
     "Logging": {
         "LogLevel": {
-            "Default": "LogAlways"
+            "Default": "Information"
         }
     }
 }

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,16 +1,16 @@
-echo "Deployment started."
+echo "[*] Deployment started..."
 sshpass -e ssh -o StrictHostKeyChecking=no root@5.63.154.249 '
     echo "[*] SSH session started..." &&
-    cd seterator&&
+    cd seterator &&
     systemctl stop seterator &&
     echo "[*] seterator.service stopped..." &&
     git pull &&
     echo "[*] Source code updated, building..." &&
     dotnet build &&
-    echo "[*] Build completed, applying migration..."
+    echo "[*] Build completed, applying migration..." &&
     dotnet ef database update --project ./Seterator/Seterator.csproj &&
     echo "[*] Migration completed, starting seterator.service..."
     systemctl start seterator &&
-    echo "[*] seterator.service started..."
+    echo "[*] seterator.service started"
 '
 echo "[*] Deployment complited"


### PR DESCRIPTION
## Зачем мы обновляемся?
- Новые классные фичи
- Улучшение производительности
- Улучшение производительности компиляции

## Почему мы теперь можем обновиться?
Со времён последнй попытки, оказывается, ошибка (https://github.com/dotnet/runtime/issues/13475), не позволявшая нам перейти на новую версию была пофикшена. Ручная проверка на серваке показала что - **да**, всё вроде работает.  

## Что сделано?
- Обновлены файлы конфигураций
- Обновлены зависисимости
- Удалены лишние зависимости
- Исправлены критичные для обновления ошибки

## Что не сделано?
Похоже, тревис сыпется при сборке проекта. Нужно разобраться почему.

***
В прошлый раз эта тема поднималась в #74 и #75 