### PR TITLE
Деплой на сервер теперь использует master-версию артефакта для rsync

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         name: app-package
     - name: rsync deployments
-      uses: oncletom/rsync-deployments@patch-1
+      uses: oncletom/rsync-deployments@master
       with:
         RSYNC_OPTIONS: -avzr --delete
         USER_AND_HOST: github-deployer@45.151.144.11


### PR DESCRIPTION
Владелец https://github.com/oncletom/rsync-deployments вмерджил пулл-реквест на который мы использовали при деплое (потому что в PR было решено несколько проблем).
Поменял на использование мастер-ветки, теперь всё должно заработать.